### PR TITLE
Remove InstalledProduct instance when a product is uninstalled

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,6 +13,11 @@ Changelog
 - Add some missing test setup.
   [davisagli]
 
+- Remove InstalledProduct instance when a product is uninstalled.
+  Leaving the instance around can prevent settings from being stored
+  properly on subsequent installation of the product.
+  [rochecompaan]
+
 3.0.5 - 2011-03-31
 ------------------
 

--- a/Products/CMFQuickInstallerTool/QuickInstallerTool.py
+++ b/Products/CMFQuickInstallerTool/QuickInstallerTool.py
@@ -616,6 +616,8 @@ class QuickInstallerTool(UniqueObject, ObjectManager, SimpleItem):
         for pid in products:
             prod=getattr(self,pid)
             prod.uninstall(cascade=cascade, reinstall=reinstall)
+            if reinstall == False:
+                self.manage_delObjects(pid)
 
         if REQUEST:
             return REQUEST.RESPONSE.redirect(REQUEST['HTTP_REFERER'])

--- a/Products/CMFQuickInstallerTool/tests/install.txt
+++ b/Products/CMFQuickInstallerTool/tests/install.txt
@@ -90,10 +90,9 @@ And we have an InstalledProduct instance in the QI tool which says the product
 is not installed anymore:
 
   >>> 'CMFCalendar' in qi.objectIds()
-  True
+  False
   
-  >>> cal = qi['CMFCalendar']
-  >>> cal.isInstalled()
+  >>> qi.isProductInstalled('CMFCalendar')
   False
 
   >>> setup = getToolByName(portal, 'portal_setup')
@@ -145,10 +144,9 @@ And we have an InstalledProduct instance in the QI tool which says the product
 is not installed anymore again:
 
   >>> 'CMFCalendar' in qi.objectIds()
-  True
+  False
   
-  >>> cal = qi['CMFCalendar']
-  >>> cal.isInstalled()
+  >>> qi.isProductInstalled('CMFCalendar')
   False
 
 Install a product which has a GenericSetup dependency


### PR DESCRIPTION
Leaving the instance around can prevent settings from being stored properly on
subsequent installation of the product. See this thread for an example of how it goes wrong: http://groups.google.com/group/dexterity-development/browse_thread/thread/975dd547b02f8e1e
