### PR TITLE
When uninstalling a product, mark its install profile as unknown.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 3.0.12 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- When uninstalling a product, mark its install profile as
+  ``unknown``, so ``portal_setup`` also regards it as not installed.
+  [maurits]
 
 
 3.0.11 (2015-08-22)

--- a/Products/CMFQuickInstallerTool/QuickInstallerTool.py
+++ b/Products/CMFQuickInstallerTool/QuickInstallerTool.py
@@ -737,11 +737,28 @@ class QuickInstallerTool(UniqueObject, ObjectManager, SimpleItem):
         """
         if products is None:
             products = []
+        portal_setup = getToolByName(self, 'portal_setup')
         for pid in products:
             prod = getattr(self, pid)
             prod.uninstall(cascade=cascade, reinstall=reinstall)
             if not reinstall:
                 self.manage_delObjects(pid)
+                profile = self.getInstallProfile(pid)
+                if profile is not None:
+                    # Mark profile as uninstalled/unknown.
+                    profile_id = profile['id']
+                    # XXX We want to use unsetLastVersionForProfile,
+                    # but that requires a merge and release of this
+                    # GenericSetup pull request:
+                    # https://github.com/zopefoundation/Products.GenericSetup/pull/18
+                    # portal_setup.unsetLastVersionForProfile(profile_id)
+                    # Instead we must copy and set the
+                    # (non-persistent) profile upgrade versions.
+                    prof_versions = portal_setup._profile_upgrade_versions.copy()
+                    if profile_id not in prof_versions:
+                        continue
+                    del prof_versions[profile_id]
+                    portal_setup._profile_upgrade_versions = prof_versions
 
         if REQUEST:
             return REQUEST.RESPONSE.redirect(REQUEST['HTTP_REFERER'])

--- a/Products/CMFQuickInstallerTool/tests/install.txt
+++ b/Products/CMFQuickInstallerTool/tests/install.txt
@@ -57,6 +57,14 @@ Now we have an InstalledProduct instance in the QI tool:
 Uninstall the product again
 ---------------------------
 
+First pretend the profile has a version:
+
+  >>> setup = getToolByName(portal, 'portal_setup')
+  >>> profile_id = qi.getInstallProfile('QITest')['id']
+  >>> setup.setLastVersionForProfile(profile_id, '42')
+
+Now uninstall the product:
+
   >>> qi.uninstallProducts(products=['QITest'])
 
 And we no longer have an InstalledProduct instance in the QI tool:
@@ -67,7 +75,12 @@ And we no longer have an InstalledProduct instance in the QI tool:
   >>> qi.isProductInstalled('QITest')
   False
 
-  >>> setup = getToolByName(portal, 'portal_setup')
+The portal_setup no longer knows its installed profile version, as we
+have cleaned that up:
+
+  >>> setup.getLastVersionForProfile(profile_id)
+  'unknown'
+
   >>> logs = [i for i in setup.objectIds() if 'QITest' in i]
   >>> for i in logs:
   ...     setup._delObject(i)


### PR DESCRIPTION
Then portal_setup also regards it as not installed.

This is the first TODO item of http://permalink.gmane.org/gmane.comp.web.zope.plone.devel/35442