### PR TITLE
fix test with changed repr

### DIFF
--- a/Products/CMFQuickInstallerTool/tests/actions.txt
+++ b/Products/CMFQuickInstallerTool/tests/actions.txt
@@ -8,8 +8,8 @@ First we set three convenience variables for later use:
   <PloneSite at /plone>
 
   >>> qi = getattr(portal, 'portal_quickinstaller', None)
-  >>> qi
-  <QuickInstallerTool at /plone/portal_quickinstaller>
+  >>> qi.__name__
+  'portal_quickinstaller'
 
   >>> actions_tool = portal.portal_actions
   >>> actions_tool
@@ -58,5 +58,5 @@ TearDown
 Make sure the QI tool is still there:
 
   >>> qi = getattr(portal, 'portal_quickinstaller', None)
-  >>> qi
-  <QuickInstallerTool at /plone/portal_quickinstaller>
+  >>> qi.__name__
+  'portal_quickinstaller'

--- a/Products/CMFQuickInstallerTool/tests/install.txt
+++ b/Products/CMFQuickInstallerTool/tests/install.txt
@@ -12,8 +12,8 @@ First we set three convenience variables for later use:
   <PloneSite at /plone>
 
   >>> qi = getattr(portal, 'portal_quickinstaller', None)
-  >>> qi
-  <QuickInstallerTool at /plone/portal_quickinstaller>
+  >>> qi.__name__
+  'portal_quickinstaller'
 
 And register the QI tool as a utility:
 

--- a/Products/CMFQuickInstallerTool/tests/profiles.txt
+++ b/Products/CMFQuickInstallerTool/tests/profiles.txt
@@ -20,8 +20,8 @@ First we set three convenience variables for later use:
   <PloneSite at /plone>
 
   >>> qi = getattr(portal, 'portal_quickinstaller', None)
-  >>> qi
-  <QuickInstallerTool at /plone/portal_quickinstaller>
+  >>> qi.__name__
+  'portal_quickinstaller'
 
   >>> actions_tool = portal.portal_actions
   >>> actions_tool


### PR DESCRIPTION
Change doctest to not rely on a specific `__repr__` of QuickInstallerTool since it makes no difference to what is tested.

See https://github.com/plone/Products.CMFPlone/issues/2590#issuecomment-432929327