### PR TITLE
Fix test failing with Zope 4.2.1

### DIFF
--- a/Products/CMFQuickInstallerTool/tests/test_browser.py
+++ b/Products/CMFQuickInstallerTool/tests/test_browser.py
@@ -96,12 +96,11 @@ class QIBrowserTest(unittest.TestCase):
         csrf_token = createToken()
         qs = 'products:list=%s&_authenticator=%s' % (product, csrf_token)
         referrer = qi.absolute_url() + '/manage_installProductsForm'
+        # Passing a referrer has changed in recent versions of zope.testbrowser.
+        # If we set it explicitly in the browser, it always works:
+        self.browser.addHeader('Referer', referrer)
         # z.testbrowser will choose POST if we provide data
-        try:
-            self.browser.open(url, qs, referrer=referrer)
-        except TypeError:
-            # old version of z.testbrowser w/o referrer
-            self.browser.open(url, qs)
+        self.browser.open(url, qs)
         # The product must have successfully been installed.
         self.assertTrue(qi.isProductInstalled(product),
                         'Failed to install %s' % product)

--- a/Products/CMFQuickInstallerTool/tests/test_browser.py
+++ b/Products/CMFQuickInstallerTool/tests/test_browser.py
@@ -94,19 +94,17 @@ class QIBrowserTest(unittest.TestCase):
         product = self._get_product_for_install(qi)
         url = '%s/installProducts' % qi.absolute_url()
         csrf_token = createToken()
-        # First we need to get a url so we have a referer to get back to.
-        # Otherwise we get a redirect to '', which means to 'installProducts',
-        # which will fail because it is a GET request.
-        self.browser.open(qi.absolute_url() + '/manage_installProductsForm')
-        # Now the POST.
-        self.browser.post(url, 'products:list=%s&_authenticator=%s' % (
-            product, csrf_token))
+        # z.testbrowser will choose POST if we provide data
+        self.browser.open(
+            url, 'products:list=%s&_authenticator=%s' % (
+                product, csrf_token),
+            referrer=qi.absolute_url() + '/manage_installProductsForm')
         # The product must have successfully been installed.
         self.assertTrue(qi.isProductInstalled(product),
                         'Failed to install %s' % product)
         self.assertEqual(
             self.browser.url,
-            'http://nohost/plone/portal_quickinstaller/manage_installProductsForm')
+            'http://nohost/plone/portal_quickinstaller/manage_installProductsForm')  # noqa: E501
 
     def test_installProducts_get(self):
         # Now with a GET request.

--- a/Products/CMFQuickInstallerTool/tests/test_browser.py
+++ b/Products/CMFQuickInstallerTool/tests/test_browser.py
@@ -94,11 +94,14 @@ class QIBrowserTest(unittest.TestCase):
         product = self._get_product_for_install(qi)
         url = '%s/installProducts' % qi.absolute_url()
         csrf_token = createToken()
+        qs = 'products:list=%s&_authenticator=%s' % (product, csrf_token)
+        referrer = qi.absolute_url() + '/manage_installProductsForm'
         # z.testbrowser will choose POST if we provide data
-        self.browser.open(
-            url, 'products:list=%s&_authenticator=%s' % (
-                product, csrf_token),
-            referrer=qi.absolute_url() + '/manage_installProductsForm')
+        try:
+            self.browser.open(url, qs, referrer=referrer)
+        except TypeError:
+            # old version of z.testbrowser w/o referrer
+            self.browser.open(url, qs)
         # The product must have successfully been installed.
         self.assertTrue(qi.isProductInstalled(product),
                         'Failed to install %s' % product)

--- a/news/23.bugfix
+++ b/news/23.bugfix
@@ -1,0 +1,2 @@
+Fix failing test.
+[tschorr]


### PR DESCRIPTION
by explicity passing a referrer.